### PR TITLE
Update Safe docs and SDK GitHub links in plugin guide

### DIFF
--- a/how-to-create-a-plugin.md
+++ b/how-to-create-a-plugin.md
@@ -100,8 +100,8 @@ const estimatedTransferGas = await sdk.eth.getEstimateGas({
 ```
 
 #### Useful links 
-- [Safe App SDK](https://github.com/gnosis/safe-apps-sdk)
-- [Safe App documentation](https://docs.gnosis-safe.io/build/sdks/safe-apps)
+- [Safe App SDK](https://github.com/safe-global/safe-apps-sdk)
+- [Safe App documentation](https://docs.safe.global/safe-mobile/safe-apps/safe-apps-overview)
 
 ### Testing the application
 You can run your dApp at this address: https://wallet.ambire.com/#/wallet/dapps


### PR DESCRIPTION
Hi Ambire team,

Small housekeeping PR for `how-to-create-a-plugin.md`. The Safe project (formerly Gnosis Safe) rebranded in July 2022 and migrated its repos and docs.

This PR updates two links in the "Useful links" section:

1. `github.com/gnosis/safe-apps-sdk` → `github.com/safe-global/safe-apps-sdk` (GitHub redirects but the new canonical owner is `safe-global`).
2. `docs.gnosis-safe.io/build/sdks/safe-apps` → `docs.safe.global/safe-mobile/safe-apps/safe-apps-overview` (the legacy `docs.gnosis-safe.io` subdomain is DNS-dead).

I intentionally left the `@gnosis.pm/safe-apps-react-sdk` import references untouched. The current package is `@safe-global/safe-apps-react-sdk`, and updating the imports is a larger change that probably needs the Ambire team's own verification with the latest API surface. Happy to file a separate issue or PR for that if you want to scope it.

Samuel Akpan
Safe Foundation
